### PR TITLE
Handle param ordering and specificity

### DIFF
--- a/lib/rewriteRules.js
+++ b/lib/rewriteRules.js
@@ -4,6 +4,7 @@ var forPathsMatching = require('en-garde').middlewares.forPathsMatching;
 var request = require('request');
 var path = require("path");
 var cachedConfig = { rules: { urls: {} } };
+var qs = require('querystring');
 var ruleApplier;
 var fs = require('fs');
 var errorTemplatePath = path.join(
@@ -32,13 +33,39 @@ function serveFile(rule, req, res, next) {
 	});
 }
 
+function parse(url) {
+	var parts = url.split('?');
+	return {
+		path: parts[0],
+		params: qs.parse(parts[1])
+	};
+}
+
+function ruleMatches(req, ruleUrl) {
+	var parsedRuleUrl = parse(ruleUrl);
+	if (req.path === parsedRuleUrl.path) {
+		return _.all(parsedRuleUrl.params, function (value, key) {
+			return req.params[key] === value;
+		});
+	}
+
+	return false;
+}
+
 function applyRule(req, res, next) {
-	var longestMatch = _(cachedConfig.rules.urls)
-							.keys()
-							.sortBy('length')
-							.filter(function (url) {
-								return req.url.indexOf(url) === 0;
-							}).last(),
+
+
+	var longestMatch =
+		_(cachedConfig.rules.urls)
+			.keys()
+			.sortBy(function (url) {
+				//More params specified = more important rule
+				var params = parse(url).params;
+				return _.keys(params).length;
+			})
+			.filter(function (url) {
+				return ruleMatches(req, url);
+			}).last(),
 
 		rule = cachedConfig.rules.urls[longestMatch];
 
@@ -60,6 +87,10 @@ function sendRules(req, res) {
 	res.send(cachedConfig);
 }
 
+function ruleUrlPath(ruleUrl) {
+	return ruleUrl.split('?')[0];
+}
+
 module.exports = {
 	getRules: function getRules() {
 		return cachedConfig;
@@ -69,7 +100,7 @@ module.exports = {
 		if (config) {
 			cachedConfig = _.merge(cachedConfig, config);
 			ruleApplier = forPathsMatching(
-				Object.keys(cachedConfig.rules.urls),
+				_(cachedConfig.rules.urls).keys().map(ruleUrlPath).value(),
 				applyRule);
 		}
 	},


### PR DESCRIPTION
- Param order no longer matters for stub rule messages
- Rules with more params are considered more "specific"
- Path now needs to be an exact match
